### PR TITLE
move submitHashes and submitFileHashes into own file

### DIFF
--- a/index.js
+++ b/index.js
@@ -347,7 +347,7 @@ export function getProofTxs(proofs) {
   return flatProofs
 }
 
-// work to keep expected import structure to maintain backwards compatibility
+// Need this to keep expected import structure for backwards compatibility
 // with downstream dependencies
 export const submitHashes = _submitHashes
 export const submitFileHashes = _submitFileHashes

--- a/lib/submit.js
+++ b/lib/submit.js
@@ -11,10 +11,10 @@
  * limitations under the License.
  */
 
-import { isFunction, isArray, isEmpty, reject, uniq, map, forEach } from 'lodash'
+import { isEmpty, reject, uniq, map, forEach } from 'lodash'
 import fetch from 'node-fetch'
 
-import { isHex, isSecureOrigin, promiseMap, getFileHashes } from './utils/helpers'
+import { isHex, isSecureOrigin, promiseMap, getFileHashes, validateHashesArg, validateUrisArg } from './utils/helpers'
 import { isValidNodeURI, getNodes } from './utils/network'
 import { mapSubmitHashesRespToProofHandles } from './utils/proofs'
 import { NODE_PROXY_URI } from './constants'
@@ -25,30 +25,17 @@ import { NODE_PROXY_URI } from './constants'
  * @param {Array<String>} uris - An Array of String URI's. Each hash will be submitted to each Node URI provided. If none provided three will be chosen at random using service discovery.
  * @return {Array<{uri: String, hash: String, hashIdNode: String, groupId: String}>} An Array of Objects, each a handle that contains all info needed to retrieve a proof.
  */
-function submitHashes(hashes, uris, callback) {
+async function submitHashes(hashes, uris) {
   uris = uris || []
-  callback = callback || function() {}
-  let nodesPromise
+  let nodes
 
-  // Validate callback is a function
-  if (!isFunction(callback)) throw new Error('callback arg must be a function')
-
-  // Validate all hashes provided
-  if (!isArray(hashes)) throw new Error('hashes arg must be an Array')
-  if (isEmpty(hashes)) throw new Error('hashes arg must be a non-empty Array')
-  if (hashes.length > 250) throw new Error('hashes arg must be an Array with <= 250 elements')
-  let rejects = reject(hashes, function(h) {
-    return isHex(h)
-  })
-  if (!isEmpty(rejects)) throw new Error(`hashes arg contains invalid hashes : ${rejects.join(', ')}`)
-
-  // Validate all Node URIs provided
-  if (!isArray(uris)) throw new Error('uris arg must be an Array of String URIs')
-  if (uris.length > 5) throw new Error('uris arg must be an Array with <= 5 elements')
+  // Validate args before doing anything else
+  validateHashesArg(hashes, h => isHex(h))
+  validateUrisArg(uris)
 
   if (isEmpty(uris)) {
     // get a list of nodes via service discovery
-    nodesPromise = getNodes(3)
+    nodes = await getNodes(3)
   } else {
     // eliminate duplicate URIs
     uris = uniq(uris)
@@ -59,73 +46,60 @@ function submitHashes(hashes, uris, callback) {
     })
     if (!isEmpty(badURIs)) throw new Error(`uris arg contains invalid URIs : ${badURIs.join(', ')}`)
     // all provided URIs were valid
-    nodesPromise = Promise.resolve(uris)
+    nodes = uris
   }
 
-  return new Promise(function(resolve, reject) {
-    // Resolve an Array of Nodes from service discovery or the arg provided
-    nodesPromise
-      .then(nodes => {
-        // Setup an options Object for each Node we'll submit hashes to.
-        // Each Node will then be sent the full Array of hashes.
-        let nodesWithPostOpts = map(nodes, node => {
-          let uri = isSecureOrigin() ? NODE_PROXY_URI : node
-          let headers = Object.assign(
-            {
-              'Content-Type': 'application/json',
-              Accept: 'application/json'
-            },
-            isSecureOrigin()
-              ? {
-                  'X-Node-Uri': node
-                }
-              : {}
-          )
+  try {
+    // Setup an options Object for each Node we'll submit hashes to.
+    // Each Node will then be sent the full Array of hashes.
+    let nodesWithPostOpts = map(nodes, node => {
+      let uri = isSecureOrigin() ? NODE_PROXY_URI : node
+      let headers = Object.assign(
+        {
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        },
+        isSecureOrigin()
+          ? {
+              'X-Node-Uri': node
+            }
+          : {}
+      )
 
-          let postOptions = {
-            method: 'POST',
-            uri: uri + '/hashes',
-            body: {
-              hashes: hashes
-            },
-            headers,
-            timeout: 10000
-          }
-          return postOptions
-        })
+      let postOptions = {
+        method: 'POST',
+        uri: uri + '/hashes',
+        body: {
+          hashes: hashes
+        },
+        headers,
+        timeout: 10000
+      }
+      return postOptions
+    })
 
-        // All requests succeed in parallel or all fail.
-        promiseMap(nodesWithPostOpts, fetch, {
-          concurrency: 25
-        }).then(
-          parsedBody => {
-            // Nodes cannot be guaranteed to know what IP address they are reachable
-            // at, so we need to amend each result with the Node URI it was submitted
-            // to so that proofs may later be retrieved from the appropriate Node(s).
-            // This mapping relies on that fact that promiseMap returns results in the
-            // same order that options were passed to it so the results can be mapped to
-            // the Nodes submitted to.
-            forEach(nodes, (uri, index) => {
-              parsedBody[index].meta.submitted_to = uri
-            })
+    // All requests succeed in parallel or all fail.
+    const parsedBody = await promiseMap(nodesWithPostOpts, fetch, {
+      concurrency: 25
+    })
+    // Nodes cannot be guaranteed to know what IP address they are reachable
+    // at, so we need to amend each result with the Node URI it was submitted
+    // to so that proofs may later be retrieved from the appropriate Node(s).
+    // This mapping relies on that fact that promiseMap returns results in the
+    // same order that options were passed to it so the results can be mapped to
+    // the Nodes submitted to.
+    forEach(nodes, (uri, index) => {
+      parsedBody[index].meta.submitted_to = uri
+    })
 
-            // Map the API response to a form easily consumable by getProofs
-            let proofHandles = mapSubmitHashesRespToProofHandles(parsedBody)
+    // Map the API response to a form easily consumable by getProofs
+    let proofHandles = mapSubmitHashesRespToProofHandles(parsedBody)
 
-            resolve(proofHandles)
-            return callback(null, proofHandles)
-          },
-          function(err) {
-            reject(err)
-            return callback(err)
-          }
-        )
-      })
-      .catch(err => {
-        console.error(err.message)
-        throw err
-      })
-  })
+    return proofHandles
+  } catch (err) {
+    console.error(err.message)
+    throw err
+  }
 }
 
 /**

--- a/lib/submit.js
+++ b/lib/submit.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2019 Tierion
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isFunction, isArray, isEmpty, reject, uniq, map, forEach } from 'lodash'
+import fetch from 'node-fetch'
+
+import { isHex, isSecureOrigin, promiseMap, getFileHashes } from './utils/helpers'
+import { isValidNodeURI, getNodes } from './utils/network'
+import { mapSubmitHashesRespToProofHandles } from './utils/proofs'
+import { NODE_PROXY_URI } from './constants'
+
+/**
+ * Submit hash(es) to one or more Nodes, returning an Array of proof handle objects, one for each submitted hash and Node combination.
+ * @param {Array<String>} hashes - An Array of String Hashes in Hexadecimal form.
+ * @param {Array<String>} uris - An Array of String URI's. Each hash will be submitted to each Node URI provided. If none provided three will be chosen at random using service discovery.
+ * @return {Array<{uri: String, hash: String, hashIdNode: String, groupId: String}>} An Array of Objects, each a handle that contains all info needed to retrieve a proof.
+ */
+function submitHashes(hashes, uris, callback) {
+  uris = uris || []
+  callback = callback || function() {}
+  let nodesPromise
+
+  // Validate callback is a function
+  if (!isFunction(callback)) throw new Error('callback arg must be a function')
+
+  // Validate all hashes provided
+  if (!isArray(hashes)) throw new Error('hashes arg must be an Array')
+  if (isEmpty(hashes)) throw new Error('hashes arg must be a non-empty Array')
+  if (hashes.length > 250) throw new Error('hashes arg must be an Array with <= 250 elements')
+  let rejects = reject(hashes, function(h) {
+    return isHex(h)
+  })
+  if (!isEmpty(rejects)) throw new Error(`hashes arg contains invalid hashes : ${rejects.join(', ')}`)
+
+  // Validate all Node URIs provided
+  if (!isArray(uris)) throw new Error('uris arg must be an Array of String URIs')
+  if (uris.length > 5) throw new Error('uris arg must be an Array with <= 5 elements')
+
+  if (isEmpty(uris)) {
+    // get a list of nodes via service discovery
+    nodesPromise = getNodes(3)
+  } else {
+    // eliminate duplicate URIs
+    uris = uniq(uris)
+
+    // non-empty, check that *all* are valid or throw
+    let badURIs = reject(uris, function(h) {
+      return isValidNodeURI(h)
+    })
+    if (!isEmpty(badURIs)) throw new Error(`uris arg contains invalid URIs : ${badURIs.join(', ')}`)
+    // all provided URIs were valid
+    nodesPromise = Promise.resolve(uris)
+  }
+
+  return new Promise(function(resolve, reject) {
+    // Resolve an Array of Nodes from service discovery or the arg provided
+    nodesPromise
+      .then(nodes => {
+        // Setup an options Object for each Node we'll submit hashes to.
+        // Each Node will then be sent the full Array of hashes.
+        let nodesWithPostOpts = map(nodes, node => {
+          let uri = isSecureOrigin() ? NODE_PROXY_URI : node
+          let headers = Object.assign(
+            {
+              'Content-Type': 'application/json',
+              Accept: 'application/json'
+            },
+            isSecureOrigin()
+              ? {
+                  'X-Node-Uri': node
+                }
+              : {}
+          )
+
+          let postOptions = {
+            method: 'POST',
+            uri: uri + '/hashes',
+            body: {
+              hashes: hashes
+            },
+            headers,
+            timeout: 10000
+          }
+          return postOptions
+        })
+
+        // All requests succeed in parallel or all fail.
+        promiseMap(nodesWithPostOpts, fetch, {
+          concurrency: 25
+        }).then(
+          parsedBody => {
+            // Nodes cannot be guaranteed to know what IP address they are reachable
+            // at, so we need to amend each result with the Node URI it was submitted
+            // to so that proofs may later be retrieved from the appropriate Node(s).
+            // This mapping relies on that fact that promiseMap returns results in the
+            // same order that options were passed to it so the results can be mapped to
+            // the Nodes submitted to.
+            forEach(nodes, (uri, index) => {
+              parsedBody[index].meta.submitted_to = uri
+            })
+
+            // Map the API response to a form easily consumable by getProofs
+            let proofHandles = mapSubmitHashesRespToProofHandles(parsedBody)
+
+            resolve(proofHandles)
+            return callback(null, proofHandles)
+          },
+          function(err) {
+            reject(err)
+            return callback(err)
+          }
+        )
+      })
+      .catch(err => {
+        console.error(err.message)
+        throw err
+      })
+  })
+}
+
+/**
+ * Submit hash(es) of selected file(s) to one or more Nodes, returning an Array of proof handle objects, one for each submitted hash and Node combination.
+ * @param {Array<String>} paths - An Array of paths of the files to be hashed.
+ * @param {Array<String>} uris - An Array of String URI's. Each hash will be submitted to each Node URI provided. If none provided three will be chosen at random using service discovery.
+ * @return {Array<{path: String, uri: String, hash: String, hashIdNode: String, groupId: String}>} An Array of Objects, each a handle that contains all info needed to retrieve a proof.
+ */
+export async function submitFileHashes(paths, uris) {
+  const hashObjs = await getFileHashes(paths, uris)
+  const hashes = hashObjs.map(hashObj => hashObj.hash)
+  const proofHandles = await submitHashes(hashes, uris)
+  return proofHandles.map(proofHandle => {
+    proofHandle.path = hashObjs.find(hashObj => hashObj.hash === proofHandle.hash).path
+    return proofHandle
+  })
+}
+
+// Expose functions
+export default submitHashes

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -134,6 +134,5 @@ export async function getFileHashes(paths, uris) {
     if (hashObj.error === 'EACCES') console.error(`Insufficient permission to read file '${hashObj.path}', skipping`)
     return hashObj.error !== 'EACCES'
   })
-  console.log('hashObjs:', hashObjs)
   return hashObjs
 }

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import crypto from 'crypto'
 import uuidValidate from 'uuid-validate'
-import { isEmpty, has, isObject, isArray, reject } from 'lodash'
+import { isEmpty, has, isObject, isArray, reject, isFunction } from 'lodash'
 
 /**
  * Checks if value is a hexadecimal string
@@ -106,25 +106,50 @@ export function promiseMap(arr, fn) {
   )
 }
 
+/*
+ * Helper function to validate a hashes argument that would be passed to other functions
+ * @param {Array<String>} hashes - An Array of String Hashes in Hexadecimal form.
+ * @param {Function} validator - a function to validate the array of items being validated
+ * @returns {void}
+ */
+export function validateHashesArg(hashes, validator) {
+  // Validate all hashes provided
+  if (!isArray(hashes)) throw new Error('hashes arg must be an Array')
+  if (isEmpty(hashes)) throw new Error('hashes arg must be a non-empty Array')
+  if (hashes.length > 250) throw new Error('hashes arg must be an Array with <= 250 elements')
+
+  if (!validator || !isFunction(validator)) throw new Error('Need a validator function to test argument')
+  let rejects = reject(hashes, validator)
+  if (!isEmpty(rejects)) throw new Error(`arg contains invalid items : ${rejects.join(', ')}`)
+}
+
+/*
+ * Helper function to validate a hashes argument that would be passed to other functions
+ * @param {Array<String>} hashes - An Array of String Hashes in Hexadecimal form.
+ * @returns {void}
+ */
+export function validateUrisArg(uris) {
+  if (!isArray(uris)) throw new Error('uris arg must be an Array of String URIs')
+  if (uris.length > 5) throw new Error('uris arg must be an Array with <= 5 elements')
+}
+
 /**
  * Get SHA256 hash(es) of selected file(s) and prepare for submitting to a node
  * @param {Array<String>} paths - An Array of paths of the files to be hashed.
- * @param {Array<String>} uris - An Array of String URI's. Each hash will be submitted to each Node URI provided. If none provided three will be chosen at random using service discovery.
- * @return {Array<{path: String, hash: String} An Array of Objects, each a handle that contains all info needed to retrieve a proof.
+ * @param {Array<String>} uris - An Array of String URI's. Each hash will be submitted to each Node URI provided.
+ * If none provided three will be chosen at random using service discovery.
+ * @returns {Array<{path: String, hash: String} An Array of Objects, each a handle that contains all info needed to retrieve a proof.
  */
 export async function getFileHashes(paths, uris) {
   uris = uris || []
 
   // Validate all paths provided
-  if (!isArray(paths)) throw new Error('paths arg must be an Array')
-  if (isEmpty(paths)) throw new Error('paths arg must be a non-empty Array')
-  if (paths.length > 250) throw new Error('paths arg must be an Array with <= 250 elements')
-  let rejects = reject(paths, path => fs.existsSync(path) && fs.lstatSync(path).isFile())
-  if (!isEmpty(rejects)) throw new Error(`paths arg contains invalid paths : ${rejects.join(', ')}`)
+  // Criteria is the same as for hashes arg so can reuse the helper
+  // except need a different validator function
+  validateHashesArg(paths, path => fs.existsSync(path) && fs.lstatSync(path).isFile())
 
   // Validate all Node URIs provided
-  if (!isArray(uris)) throw new Error('uris arg must be an Array of String URIs')
-  if (uris.length > 5) throw new Error('uris arg must be an Array with <= 5 elements')
+  validateUrisArg(uris)
 
   let hashObjs = []
   hashObjs = await Promise.all(paths.map(path => sha256FileByPath(path)))

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import crypto from 'crypto'
 import uuidValidate from 'uuid-validate'
-import { isEmpty, has, isObject } from 'lodash'
+import { isEmpty, has, isObject, isArray, reject } from 'lodash'
 
 /**
  * Checks if value is a hexadecimal string
@@ -104,4 +104,36 @@ export function promiseMap(arr, fn) {
       }
     })
   )
+}
+
+/**
+ * Get SHA256 hash(es) of selected file(s) and prepare for submitting to a node
+ * @param {Array<String>} paths - An Array of paths of the files to be hashed.
+ * @param {Array<String>} uris - An Array of String URI's. Each hash will be submitted to each Node URI provided. If none provided three will be chosen at random using service discovery.
+ * @return {Array<{path: String, hash: String} An Array of Objects, each a handle that contains all info needed to retrieve a proof.
+ */
+export async function getFileHashes(paths, uris) {
+  uris = uris || []
+
+  // Validate all paths provided
+  if (!isArray(paths)) throw new Error('paths arg must be an Array')
+  if (isEmpty(paths)) throw new Error('paths arg must be a non-empty Array')
+  if (paths.length > 250) throw new Error('paths arg must be an Array with <= 250 elements')
+  let rejects = reject(paths, path => fs.existsSync(path) && fs.lstatSync(path).isFile())
+  if (!isEmpty(rejects)) throw new Error(`paths arg contains invalid paths : ${rejects.join(', ')}`)
+
+  // Validate all Node URIs provided
+  if (!isArray(uris)) throw new Error('uris arg must be an Array of String URIs')
+  if (uris.length > 5) throw new Error('uris arg must be an Array with <= 5 elements')
+
+  let hashObjs = []
+  hashObjs = await Promise.all(paths.map(path => sha256FileByPath(path)))
+
+  // filter out any EACCES errors
+  hashObjs = hashObjs.filter(hashObj => {
+    if (hashObj.error === 'EACCES') console.error(`Insufficient permission to read file '${hashObj.path}', skipping`)
+    return hashObj.error !== 'EACCES'
+  })
+  console.log('hashObjs:', hashObjs)
+  return hashObjs
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -17,4 +17,5 @@ import * as helpers from './helpers'
 import * as proofs from './proofs'
 import * as network from './network'
 
+export { helpers, proofs, network }
 export default { ...helpers, ...proofs, ...network }

--- a/lib/utils/network.js
+++ b/lib/utils/network.js
@@ -11,6 +11,11 @@
  * limitations under the License.
  */
 
+/*
+ * helper functions related to interact with chainpoint network objects
+ * such as nodes and cores
+ */
+
 const dns = require('dns')
 import url from 'url'
 import { isInteger, isFunction, isEmpty, slice, map, shuffle, filter, first, isString } from 'lodash'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
     "lint": "eslint lib/**/*.js *.js",
-    "test": "nyc mocha --reporter spec tests/*-test.js",
+    "test": "npm run webpack && nyc mocha --reporter spec tests/*-test.js",
     "test:watch": "mocha --reporter spec --watch tests/*-test.js",
     "webpack": "webpack",
     "prepublishOnly": "webpack"


### PR DESCRIPTION
Aside from modularizing the functions this also simplifies `submitFileHashes` by splitting out functionality. There is now a new helper `getFileHashes` that runs the checks on the paths and then gets the sha256 hashes. `submitFileHashes` simply runs that to get the hashes and then submits them to a node. 

This is also a test run of converting to async/await. 

I still want to test this against the `cli` tests to make sure it won't break any outside dependencies (you can see in the `index.js` file where I did some weird exporting, that was to fix some related issues that were coming up in the test), but this should give a good idea of where I'm going with this modularization story.