### PR TITLE
Add support for setting configs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 Tierion
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Config from 'bcfg'
+
+let config = null
+
+function getConfig(options = {}) {
+  // if (config) {
+  //   config.inject(options)
+  //   return config
+  // }
+
+  // create a new config module for chainpoint
+  // this will set the prefix to `~/.chainpoint`
+  // and also parse env vars that are prefixed with `CHAINPOINT_`
+  config = new Config('chainpoint')
+  config.inject(options)
+  config.load({
+    // Parse URL hash
+    hash: true,
+    // Parse querystring
+    query: true,
+    // Parse environment
+    env: true,
+    // Parse args
+    argv: true
+  })
+
+  // Will parse [PREFIX]/chainpoint.conf (throws on FS error).
+  // PREFIX defaults to `~/.chainpoint`
+  // can change the prefix by passing in a `prefix` option
+  config.open('chainpoint.conf')
+  return config
+}
+
+export default getConfig

--- a/lib/get.js
+++ b/lib/get.js
@@ -16,8 +16,10 @@ import { isEmpty, forEach, map, every, reject, keys, flatten, mapKeys, camelCase
 import { isValidNodeURI } from './utils/network'
 import { isValidProofHandle } from './utils/proofs'
 import { isSecureOrigin, isValidUUID, fetchEndpoints, testArrayArg } from './utils/helpers'
+import getConfig from './config'
 import { NODE_PROXY_URI } from './constants'
 
+let config = getConfig()
 /**
  * Retrieve a collection of proofs for one or more hash IDs from the appropriate Node(s)
  * The output of `submitProofs()` can be passed directly as the `proofHandles` arg to
@@ -93,7 +95,7 @@ async function getProofs(proofHandles) {
       )
       let getOptions = {
         method: 'GET',
-        uri: (isSecureOrigin() ? NODE_PROXY_URI : node) + '/proofs',
+        uri: (isSecureOrigin() ? config.str('node-proxy-uri', NODE_PROXY_URI) : node) + '/proofs',
         body: {},
         headers,
         timeout: 10000

--- a/lib/submit.js
+++ b/lib/submit.js
@@ -17,7 +17,9 @@ import { isHex, isSecureOrigin, fetchEndpoints, validateHashesArg, validateUrisA
 import { isValidNodeURI, getNodes } from './utils/network'
 import { mapSubmitHashesRespToProofHandles } from './utils/proofs'
 import { NODE_PROXY_URI } from './constants'
+import getConfig from './config'
 
+let config = getConfig()
 /**
  * Submit hash(es) to one or more Nodes, returning an Array of proof handle objects, one for each submitted hash and Node combination.
  * @param {Array<String>} hashes - An Array of String Hashes in Hexadecimal form.
@@ -52,7 +54,7 @@ export async function submitHashes(hashes, uris) {
     // Setup an options Object for each Node we'll submit hashes to.
     // Each Node will then be sent the full Array of hashes.
     let nodesWithPostOpts = map(nodes, node => {
-      let uri = isSecureOrigin() ? NODE_PROXY_URI : node
+      let uri = isSecureOrigin() ? config.str('node-proxy-uri', NODE_PROXY_URI) : node
       let headers = Object.assign(
         {
           'Content-Type': 'application/json',

--- a/lib/utils/network.js
+++ b/lib/utils/network.js
@@ -125,7 +125,7 @@ export async function getNodes(num) {
 
   if (!isInteger(num) || num < 1) throw new Error('num arg must be an Integer >= 1')
 
-  // TODO: Replace hard coded value with configurable env vars
+  // get cores uri from configs, if none, then check with getCores
   let coreURI = config.array('cores')
   if (!coreURI) coreURI = await getCores(1)
   let getNodeURI = first(coreURI) + '/nodes/random'

--- a/lib/utils/network.js
+++ b/lib/utils/network.js
@@ -21,10 +21,12 @@ import { parse } from 'url'
 import { promisify } from 'util'
 import { isInteger, isFunction, isEmpty, slice, map, shuffle, filter, first, isString } from 'lodash'
 import { isURL, isIP } from 'validator'
-import fetch from 'node-fetch'
+const { AbortController, abortableFetch } = require('abortcontroller-polyfill/dist/cjs-ponyfill')
+const { fetch } = abortableFetch(require('node-fetch'))
 
 import getConfig from '../config'
 import { DNS_CORE_DISCOVERY_ADDR } from '../constants'
+import { testArrayArg } from './helpers'
 
 let config = getConfig()
 
@@ -140,28 +142,57 @@ export async function getNodes(num) {
     return isValidNodeURI(n)
   })
 
-  let testedNodes = []
   let failedNodes = []
 
   // since not all nodes returned from a core are guaranteed to work
-  // we need to test each one until we have the number originally requested
-  for (let node of filteredNodes) {
-    try {
-      await fetch(node, { timeout: 150, method: 'GET' })
-      testedNodes.push(node)
-      // if we have enough nodes, we don't need to test anymore
-      if (testedNodes.length === num) break
-    } catch (e) {
-      // store failed nodes so that they can be logged
-      failedNodes.push(node)
-    }
-  }
+  // we need to test each one
+  let testedNodes = await testNodeEndpoints(filteredNodes, failedNodes)
 
-  if (failedNodes.length) console.error('Could not connect to the following nodes:\n', failedNodes.join(',\n'))
+  // remove any that have failed and slice to requested number
+  let slicedNodes = testedNodes.filter(node => node).slice(0, num)
+
+  if (failedNodes.length)
+    console.error(
+      `Could not connect to the following nodes provided by core ${first(coreURI)}:\n`,
+      failedNodes.join(',\n')
+    )
 
   // We should never return an empty array of nodes
-  if (!testedNodes.length)
+  if (!slicedNodes.length)
     throw new Error('There seems to be an issue retrieving a list of available nodes. Please try again.')
 
-  return testedNodes
+  return slicedNodes
+}
+
+/**
+ * Test an array of node uris to see if they are responding to requests.
+ * Adds cross-platform support for a timeout to make the check faster. The browser's fetch
+ * does not support a timeout paramater so need to add with AbortController
+ *
+ * @param {String[]} nodes - array of node URIs
+ * @param {Array} failures - Need an external array to be passed to track failures
+ * @returns {Promise} - returns a Promise.all that resolves to an array of urls. Any that fail return as undefined
+ * and should be filtered out of the final result
+ */
+export function testNodeEndpoints(nodes, failures = [], timeout = 150) {
+  testArrayArg(nodes)
+  return Promise.all(
+    nodes.map(async node => {
+      try {
+        isValidNodeURI(node)
+        let controller, signal, timeoutId
+        if (AbortController) {
+          controller = new AbortController()
+          signal = controller.signal
+          timeoutId = setTimeout(() => controller.abort(), timeout)
+        }
+        await fetch(node, { timeout, method: 'GET', signal })
+
+        clearTimeout(timeoutId)
+        return node
+      } catch (e) {
+        failures.push(node)
+      }
+    })
+  )
 }

--- a/lib/utils/network.js
+++ b/lib/utils/network.js
@@ -19,11 +19,14 @@
 import { resolveTxt } from 'dns'
 import { parse } from 'url'
 import { promisify } from 'util'
-import { isInteger, isFunction, isEmpty, slice, map, shuffle, filter, isString } from 'lodash'
+import { isInteger, isFunction, isEmpty, slice, map, shuffle, filter, first, isString } from 'lodash'
 import { isURL, isIP } from 'validator'
 import fetch from 'node-fetch'
 
+import getConfig from '../config'
 import { DNS_CORE_DISCOVERY_ADDR } from '../constants'
+
+let config = getConfig()
 
 /**
  * Check if valid Core URI
@@ -84,7 +87,8 @@ export async function getCores(num) {
 
   if (resolveTxt && isFunction(resolveTxt)) {
     let resolveTxtAsync = promisify(resolveTxt)
-    let records = await resolveTxtAsync(DNS_CORE_DISCOVERY_ADDR)
+    let coreDiscovery = config.str('core-discovery-addr', DNS_CORE_DISCOVERY_ADDR)
+    let records = await resolveTxtAsync(coreDiscovery)
 
     if (isEmpty(records)) throw new Error('no core addresses available')
 
@@ -103,7 +107,7 @@ export async function getCores(num) {
   } else {
     // `dns` module is not available in the browser
     // fallback to simple random selection of Cores
-    let cores = ['https://a.chainpoint.org', 'https://b.chainpoint.org', 'https://c.chainpoint.org']
+    let cores = config.array('cores', ['http://35.245.211.97'])
     return slice(shuffle(cores), 0, num)
   }
 }
@@ -122,9 +126,9 @@ export async function getNodes(num) {
   if (!isInteger(num) || num < 1) throw new Error('num arg must be an Integer >= 1')
 
   // TODO: Replace hard coded value with configurable env vars
-  // let coreURI = await getCores(1)
-  // let getNodeURI = first(coreURI) + '/nodes/random'
-  let getNodeURI = 'http://35.245.211.97/nodes/random'
+  let coreURI = config.array('cores')
+  if (!coreURI) coreURI = await getCores(1)
+  let getNodeURI = first(coreURI) + '/nodes/random'
   let response = await fetch(getNodeURI)
   response = await response.json()
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -20,6 +20,9 @@ import { fetchEndpoints, isSecureOrigin } from './utils/helpers'
 // it was called
 import * as evaluate from './evaluate'
 import { NODE_PROXY_URI } from './constants'
+import getConfig from './config'
+
+let config = getConfig()
 
 /**
  * Verify a collection of proofs using an optionally provided Node URI
@@ -73,7 +76,7 @@ export default async function verifyProofs(proofs, uri) {
         : {}
     )
 
-    let uri = isSecureOrigin() ? NODE_PROXY_URI + url.parse(anchorURI).path : anchorURI
+    let uri = isSecureOrigin() ? config.str('node-proxy-uri', NODE_PROXY_URI) + url.parse(anchorURI).path : anchorURI
 
     return {
       method: 'GET',

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.4.3",
     "@ungap/url-search-params": "^0.1.2",
+    "abortcontroller-polyfill": "^1.3.0",
     "bcfg": "^0.1.6",
     "chainpoint-parse": "^3.2.0",
     "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
     "lint": "eslint lib/**/*.js *.js",
-    "test": "npm run test:lint && nyc mocha --reporter spec -r esm 'tests/!(e2e)*-test.js'",
+    "test": "CHAINPOINT_CORES=http://35.245.211.97 npm run test:lint && nyc mocha --reporter spec -r esm 'tests/!(e2e)*-test.js'",
     "test:lint": "npm run lint",
-    "test:unit": "nyc mocha --reporter spec -r esm 'tests/!(e2e)*-test.js'",
-    "test:watch": "nyc mocha --reporter spec -r esm --watch 'tests/!(e2e)*-test.js'",
+    "test:unit": "CHAINPOINT_CORES=http://35.245.211.97 nyc mocha --reporter spec -r esm 'tests/!(e2e)*-test.js'",
+    "test:watch": "CHAINPOINT_CORES=http://35.245.211.97 nyc mocha --reporter spec -r esm --watch 'tests/!(e2e)*-test.js'",
     "test:e2e": "npm run webpack && mocha --reporter spec -r esm tests/e2e-test.js",
     "webpack": "webpack",
     "prepublishOnly": "webpack"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.4.3",
     "@ungap/url-search-params": "^0.1.2",
+    "bcfg": "^0.1.6",
     "chainpoint-parse": "^3.2.0",
     "lodash": "^4.17.11",
     "node-fetch": "^2.3.0",

--- a/tests/config-test.js
+++ b/tests/config-test.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2019 Tierion
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import getConfig from '../lib/config'
+import { expect } from 'chai'
+import Config from 'bcfg'
+import fs from 'bfile'
+
+describe('config', () => {
+  let foo, prefix, config
+  beforeEach(async () => {
+    foo = 'bar'
+    prefix = '/tmp/chainpoint_tests'
+    fs.mkdirSync(prefix)
+  })
+
+  afterEach(async () => {
+    await fs.remove(prefix)
+    config = null
+  })
+
+  it('should return a bcfg object', () => {
+    config = getConfig()
+    expect(config).to.be.an.instanceof(Config)
+  })
+
+  it('should load env vars', () => {
+    process.env.CHAINPOINT_FOO = foo
+    config = getConfig()
+    expect(config.str('foo')).to.equal(foo)
+    delete process.env.CHAINPOINT_FOO
+  })
+
+  it('should load options that are passed to it', () => {
+    config = getConfig({ foo })
+    expect(config.str('foo')).to.equal(foo)
+  })
+
+  it('should load argv', () => {
+    process.argv.push(`--foo=${foo}`)
+    config = getConfig()
+    expect(config.str('foo')).to.equal(foo)
+    // remove variable from argv
+    process.argv.pop()
+  })
+
+  it('should load configs from a config file', async () => {
+    fs.writeFileSync(prefix + '/chainpoint.conf', 'foo: bar')
+    config = getConfig({ prefix })
+    expect(config.str('foo')).to.equal(foo)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,6 +1231,13 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+bcfg@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/bcfg/-/bcfg-0.1.6.tgz#f77a6323bddef14f3886222e7ef8ccc0bc2143ec"
+  integrity sha512-BR2vwQZwu24aRm588XHOnPVjjQtbK8sF0RopRFgMuke63/REJMWnePTa2YHKDBefuBYiVdgkowuB1/e4K7Ue3g==
+  dependencies:
+    bsert "~0.0.10"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -1380,6 +1387,11 @@ browserslist@^4.3.4:
     caniuse-lite "^1.0.30000928"
     electron-to-chromium "^1.3.100"
     node-releases "^1.1.3"
+
+bsert@~0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/bsert/-/bsert-0.0.10.tgz#231ac82873a1418c6ade301ab5cd9ae385895597"
+  integrity sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q==
 
 buffer-from@^1.0.0:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,6 +773,11 @@ abbrev@1, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
+abortcontroller-polyfill@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.3.0.tgz#de69af32ae926c210b7efbcc29bf644ee4838b00"
+  integrity sha512-lbWQgf+eRvku3va8poBlDBO12FigTQr9Zb7NIjXrePrhxWVKdCP2wbDl1tLDaYa18PWTom3UEWwdH13S46I+yA==
+
 acorn-dynamic-import@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"


### PR DESCRIPTION
This implements [bcfg](https://github.com/bcoin-org/bcfg) for handling config parsing adding the ability to set configs by passing in an options object, using a config file, env vars prefaced with `CHAINPOINT_` or passing via argv in command line. 

This PR also uses this new interface for passing two values that are available as constants in the code base and instead uses those constants as a fallback. 